### PR TITLE
re-enable ios tests

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -9,12 +9,10 @@ browsers:
   - name: ie
     version: 10..latest
   - name: microsoftedge
-    version: 20..latest
-# iOS tests disabled because Saucelabs keeps timing out.
-# Tested manually, tests pass in iOS 8+.
-#  - name: iphone
-#    version: [7.0, 8.4, 9.1..latest]
-#  - name: ipad
-#    version: [7.0, 8.4, 9.1..latest]
+    version: 13..latest
+  - name: iphone
+    version: [7.0, 8.4, 9.1..latest]
+  - name: ipad
+    version: [7.0, 8.4, 9.1..latest]
   - name: android
     version: 4.4..latest

--- a/package.json
+++ b/package.json
@@ -45,16 +45,19 @@
     "jshint": "2.8.0",
     "mkdirp": "^0.5.1",
     "mocha": "^2.4.5",
-    "phantomjs": "^2.1.3",
+    "phantomjs-prebuilt": "^2.1.5",
     "pseudo-worker": "^1.0.2",
     "rimraf": "^2.5.2",
     "run-scripts": "^0.4.0",
     "stream-to-promise": "^1.1.0",
-    "zuul": "^3.9.0"
+    "zuul": "^3.10.1"
   },
   "dependencies": {
     "is-promise": "^2.1.0",
     "lie": "^3.0.2"
   },
-  "files": ["index.js", "register.js"]
+  "files": [
+    "index.js",
+    "register.js"
+  ]
 }


### PR DESCRIPTION
These tests were failing before due to Saucelabs problems; let's see if they're still failing.