### PR TITLE
Use MessageChannel to support Chrome <51, test with localtunnel.me for https

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,18 +1,21 @@
 ui: mocha-bdd
+tunnel:
+  type: localtunnel
+  https: true
 browsers:
   - name: chrome
-    version: 50..latest
+    version: 42..latest
   - name: firefox
     version: 45..latest
   - name: safari
-    version: [7, 8, 9..latest]
+    version: [8, 9..latest]
   - name: ie
     version: 10..latest
   - name: microsoftedge
     version: 13..latest
   - name: iphone
-    version: [7.0, 8.4, 9.2]
+    version: [8.4, 9.2]
   - name: ipad
-    version: [7.0, 8.4, 9.2]
+    version: [8.4, 9.2]
   - name: android
     version: 4.4..latest

--- a/index.js
+++ b/index.js
@@ -13,31 +13,35 @@ function parseJsonSafely(str) {
   }
 }
 
+function onMessage(self, e) {
+  var message = parseJsonSafely(e.data);
+  if (!message) {
+    // Ignore - this message is not for us.
+    return;
+  }
+  var messageId = message[0];
+  var error = message[1];
+  var result = message[2];
+
+  var callback = self._callbacks[messageId];
+
+  if (!callback) {
+    // Ignore - user might have created multiple PromiseWorkers.
+    // This message is not for us.
+    return;
+  }
+
+  delete self._callbacks[messageId];
+  callback(error, result);
+}
+
 function PromiseWorker(worker) {
   var self = this;
   self._worker = worker;
   self._callbacks = {};
 
-  worker.addEventListener('message', function onIncomingMessage(e) {
-    var message = parseJsonSafely(e.data);
-    if (!message) {
-      // Ignore - this message is not for us.
-      return;
-    }
-    var messageId = message[0];
-    var error = message[1];
-    var result = message[2];
-
-    var callback = self._callbacks[messageId];
-
-    if (!callback) {
-      // Ignore - user might have created multiple PromiseWorkers.
-      // This message is not for us.
-      return;
-    }
-
-    delete self._callbacks[messageId];
-    callback(error, result);
+  worker.addEventListener('message', function (e) {
+    onMessage(self, e);
   });
 }
 
@@ -57,8 +61,13 @@ PromiseWorker.prototype.postMessage = function (userMessage) {
     var jsonMessage = JSON.stringify(messageToSend);
     /* istanbul ignore if */
     if (typeof self._worker.controller !== 'undefined') {
-      // service worker
-      self._worker.controller.postMessage(jsonMessage);
+      // service worker, use MessageChannels because e.source is broken in Chrome < 51:
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=543198
+      var channel = new MessageChannel();
+      channel.port1.onmessage = function (e) {
+        onMessage(self, e);
+      };
+      self._worker.controller.postMessage(jsonMessage, [channel.port2]);
     } else {
       // web worker
       self._worker.postMessage(jsonMessage);

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "run-scripts": "^0.4.0",
     "stream-to-promise": "^1.1.0",
     "uglify-js": "^2.7.0",
-    "zuul": "^3.10.1"
+    "zuul": "^3.10.1",
+    "zuul-localtunnel": "nolanlawson/zuul-localtunnel#https"
   },
   "dependencies": {
     "is-promise": "^2.1.0",

--- a/register.js
+++ b/register.js
@@ -16,7 +16,7 @@ function registerPromiseWorker(callback) {
     function postMessage(msg) {
       /* istanbul ignore if */
       if (typeof self.postMessage !== 'function') { // service worker
-        e.source.postMessage(msg);
+        e.ports[0].postMessage(msg);
       } else { // web worker
         self.postMessage(msg);
       }

--- a/test/test.js
+++ b/test/test.js
@@ -185,7 +185,6 @@ describe('service worker test suite', function () {
     return;
   }
 
-  var failed;
   var worker;
 
   before(function () {
@@ -209,16 +208,10 @@ describe('service worker test suite', function () {
       });
     }).then(function (theWorker) {
       worker = theWorker;
-    }).catch(function (err) {
-      console.log('failed to install service worker, bailing out', err);
-      failed = true;
     });
   });
 
   it('echoes a message', function () {
-    if (failed) {
-      return;
-    }
     var promiseWorker = new PromiseWorker(worker);
 
     return promiseWorker.postMessage('ping').then(function (res) {
@@ -227,9 +220,6 @@ describe('service worker test suite', function () {
   });
 
   it('echoes a message multiple times', function () {
-    if (failed) {
-      return;
-    }
     var promiseWorker = new PromiseWorker(worker);
 
     var words = [


### PR DESCRIPTION
I decided to go with localtunnel.me because ngrok, although it also gave me https, was
too restrictive with the concurrent number of tunnels. I tested manually and confirmed that
this is actually testing https and actually testing Service Worker.

Unfortunately I had to set tested Chrome versions to 42+ because, although Service Worker is
in 40 and 41, it has some bug in MessageChannels that breaks the test (no time to debug to
figure out what the issue was). Luckily Chrome 40 and 41 have very low usage.