### PR TITLE
Avoid JSON parsing and stringifying

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,17 +5,9 @@ var MyPromise = typeof Promise !== 'undefined' ? Promise : require('lie');
 
 var messageIds = 0;
 
-function parseJsonSafely(str) {
-  try {
-    return JSON.parse(str);
-  } catch (e) {
-    return false;
-  }
-}
-
 function onMessage(self, e) {
-  var message = parseJsonSafely(e.data);
-  if (!message) {
+  var message = e.data
+  if (!Array.isArray(message) || message.length !== 3) {
     // Ignore - this message is not for us.
     return;
   }
@@ -58,7 +50,7 @@ PromiseWorker.prototype.postMessage = function (userMessage) {
       }
       resolve(result);
     };
-    var jsonMessage = JSON.stringify(messageToSend);
+
     /* istanbul ignore if */
     if (typeof self._worker.controller !== 'undefined') {
       // service worker, use MessageChannels because e.source is broken in Chrome < 51:
@@ -67,10 +59,10 @@ PromiseWorker.prototype.postMessage = function (userMessage) {
       channel.port1.onmessage = function (e) {
         onMessage(self, e);
       };
-      self._worker.controller.postMessage(jsonMessage, [channel.port2]);
+      self._worker.controller.postMessage(messageToSend, [channel.port2]);
     } else {
       // web worker
-      self._worker.postMessage(jsonMessage);
+      self._worker.postMessage(messageToSend);
     }
   });
 };

--- a/register.js
+++ b/register.js
@@ -2,14 +2,6 @@
 
 var isPromise = require('is-promise');
 
-function parseJsonSafely(str) {
-  try {
-    return JSON.parse(str);
-  } catch (e) {
-    return false;
-  }
-}
-
 function registerPromiseWorker(callback) {
 
   function postOutgoingMessage(e, messageId, error, result) {
@@ -29,11 +21,11 @@ function registerPromiseWorker(callback) {
         // to silence it.
         console.error('Worker caught an error:', error);
       }
-      postMessage(JSON.stringify([messageId, {
+      postMessage([messageId, {
         message: error.message
-      }]));
+      }]);
     } else {
-      postMessage(JSON.stringify([messageId, null, result]));
+      postMessage([messageId, null, result]);
     }
   }
 
@@ -46,7 +38,6 @@ function registerPromiseWorker(callback) {
   }
 
   function handleIncomingMessage(e, callback, messageId, message) {
-
     var result = tryCatchFunc(callback, message);
 
     if (result.err) {
@@ -63,9 +54,9 @@ function registerPromiseWorker(callback) {
   }
 
   function onIncomingMessage(e) {
-    var payload = parseJsonSafely(e.data);
-    if (!payload) {
-      // message isn't stringified json; ignore
+    var payload = e.data
+    if (!Array.isArray(payload) || payload.length !== 2) {
+      // message doens't match communication format; ignore
       return;
     }
     var messageId = payload[0];


### PR DESCRIPTION
The main goal of that PR is to improve performance by removing unnecessary json parsing/stringifying. Web Workers support fast communication when sending objects (using structured cloning) - by converting everything to string we are losing that optimization. More information: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers#Transferring_data_to_and_from_workers_further_details
and:
https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm