### PR TITLE
Update TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,4 +21,4 @@ declare class PromiseWorker {
   public postMessage<TResult = any, TInput = any>(userMessage: TInput): Promise<TResult>;
 }
 
-export = PromiseWorker;
+export default PromiseWorker;

--- a/register.d.ts
+++ b/register.d.ts
@@ -7,4 +7,4 @@ declare function registerPromiseWorker<TMessageIn = any, TMessageOut = any>(
   callback: (message: TMessageIn) => Promise<TMessageOut> | TMessageOut
 ): void;
 
-export = registerPromiseWorker;
+export default registerPromiseWorker;


### PR DESCRIPTION
Current TS definitions is not compatible with ES6 styles:

```ts
import PromiseWorker from 'promise-worker';
// -> Module '"(...)/node_modules/promise-worker/index"' has no default export.

import * as PromiseWorker from 'promise-worker';
// -> Module '"(...)/node_modules/promise-worker/index"' resolves to a non-module entity and cannot be imported using this construct.
```
The way currently available is `import PromiseWorker = require( 'promise-worker' )`, but it force to turn off `no-require-imports` option of TSLint, although most [@types](https://github.com/DefinitelyTyped/DefinitelyTyped) definition packages supports ES6 import style. 

This PR updates definition files and make the package able to be imported with ES6 style. 